### PR TITLE
FIX: keep latinate characters (#148)

### DIFF
--- a/tests/get_events_test.py
+++ b/tests/get_events_test.py
@@ -8,7 +8,7 @@ import get_events
 class GetEventsTestCase(unittest.TestCase):
 
     def setUp(self):
-        pass
+        self.maxDiff = None
 
     def tearDown(self):
         pass
@@ -36,6 +36,11 @@ class GetEventsTestCase(unittest.TestCase):
     def test_unicoder_quotes(self):
         result = get_events.unicoder('â€œ')
         expected = '“'
+        self.assertEqual(result, expected)
+
+    def test_unicoder_accents(self):
+        result = get_events.unicoder('áéíóúüñ¿¡')
+        expected = 'áéíóúüñ¿¡'
         self.assertEqual(result, expected)
 
     def test_date_filter(self):


### PR DESCRIPTION
Although encoding event text as windows-1252 and then decoding to utf8 was good for converting nonsense like `â€“` to a dash (`-`), it was removing latinate characters. This fix prevents that.