### PR TITLE
ENH: Added category names to the eventbrite sources

### DIFF
--- a/events/ans.py
+++ b/events/ans.py
@@ -53,10 +53,10 @@ def get_missing_locations(event_website, event_venue):
         ps_with_location = soup.find_all('p', {"style": "padding-left: 40px;"})
         missing_locations = []
         for p in ps_with_location:
-            p_text = p.find("em").text
-            location = p_text.replace("Location:", "").split("–")[0].strip()
-            missing_locations.append(location)
-
+            if p.find("em") is not None:
+                p_text = p.find("em").text
+                location = p_text.replace("Location:", "").split("–")[0].strip()
+                missing_locations.append(location)
         return missing_locations
 
 

--- a/events/ans.py
+++ b/events/ans.py
@@ -55,7 +55,8 @@ def get_missing_locations(event_website, event_venue):
         for p in ps_with_location:
             if p.find("em") is not None:
                 p_text = p.find("em").text
-                location = p_text.replace("Location:", "").split("–")[0].strip()
+                location = p_text.replace("Location:", "").split("–")[0]
+                location = location.strip()
                 missing_locations.append(location)
         return missing_locations
 

--- a/events/dc_audubon.py
+++ b/events/dc_audubon.py
@@ -13,15 +13,21 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+
 def get_category_name(page):
     if page["category_id"] is None:
         category = 'none'
     else:
         if page["subcategory_id"] is None:
-            category = get(page["category_id"],'categories/').json()["name"]
+            category = get(page["category_id"], 'categories/').json()["name"]
         else:
-            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+            category_name = get(page["category_id"], 'categories/')
+            category_name = category_name.json()["name"]
+            subcategory_name = get(page["subcategory_id"], 'subcategories/')
+            subcategory_name = subcategory_name.json()["name"]
+            category = category_name + "::" + subcategory_name
     return category
+
 
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()

--- a/events/dc_audubon.py
+++ b/events/dc_audubon.py
@@ -13,6 +13,15 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+def get_category_name(page):
+    if page["category_id"] is None:
+        category = 'none'
+    else:
+        if page["subcategory_id"] is None:
+            category = get(page["category_id"],'categories/').json()["name"]
+        else:
+            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+    return category
 
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()
@@ -35,7 +44,7 @@ def scrape(event_id, event_cost):
         'Event Cost': event_cost,
         'Event Currency Symbol': "$",
         # TODO: parse event data for optional category fields if present
-        'Event Category': "",  
+        'Event Category': get_category_name(page),  
         'Event Website': page['url'],
         'Event Featured Image': ""
     }

--- a/events/dc_audubon.py
+++ b/events/dc_audubon.py
@@ -16,16 +16,18 @@ except KeyError:
 
 def get_category_name(page):
     if page["category_id"] is None:
-        category = 'none'
+        category = ''
     else:
         if page["subcategory_id"] is None:
             category = get(page["category_id"], 'categories/').json()["name"]
         else:
             category_name = get(page["category_id"], 'categories/')
             category_name = category_name.json()["name"]
+            category_name = category_name.replace(",", "")
             subcategory_name = get(page["subcategory_id"], 'subcategories/')
             subcategory_name = subcategory_name.json()["name"]
-            category = category_name + "::" + subcategory_name
+            subcategory_name = subcategory_name.replace(",", "")
+            category = category_name + "," + subcategory_name
     return category
 
 

--- a/events/fona.py
+++ b/events/fona.py
@@ -14,6 +14,21 @@ except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
 
+def get_category_name(page):
+    if page["category_id"] is None:
+        category = 'none'
+    else:
+        if page["subcategory_id"] is None:
+            category = get(page["category_id"], 'categories/').json()["name"]
+        else:
+            category_name = get(page["category_id"], 'categories/')
+            category_name = category_name.json()["name"]
+            subcategory_name = get(page["subcategory_id"], 'subcategories/')
+            subcategory_name = subcategory_name.json()["name"]
+            category = category_name + "::" + subcategory_name
+    return category
+
+
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()
     venue = get(page["venue_id"], resource='venues').json()
@@ -35,7 +50,7 @@ def scrape(event_id, event_cost):
         'Event Cost': event_cost,
         'Event Currency Symbol': "$",
         # TODO: parse event data for optional category fields if present
-        'Event Category': "",  
+        'Event Category': get_category_name(page),  
         'Event Website': page['url'],
         'Event Featured Image': ""
     }

--- a/events/fona.py
+++ b/events/fona.py
@@ -16,16 +16,18 @@ except KeyError:
 
 def get_category_name(page):
     if page["category_id"] is None:
-        category = 'none'
+        category = ''
     else:
         if page["subcategory_id"] is None:
             category = get(page["category_id"], 'categories/').json()["name"]
         else:
             category_name = get(page["category_id"], 'categories/')
             category_name = category_name.json()["name"]
+            category_name = category_name.replace(",", "")
             subcategory_name = get(page["subcategory_id"], 'subcategories/')
             subcategory_name = subcategory_name.json()["name"]
-            category = category_name + "::" + subcategory_name
+            subcategory_name = subcategory_name.replace(",", "")
+            category = category_name + "," + subcategory_name
     return category
 
 

--- a/events/friends_of_kenilworth_gardens.py
+++ b/events/friends_of_kenilworth_gardens.py
@@ -13,16 +13,22 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+
 def get_category_name(page):
     if page["category_id"] is None:
         category = 'none'
     else:
         if page["subcategory_id"] is None:
-            category = get(page["category_id"],'categories/').json()["name"]
+            category = get(page["category_id"], 'categories/').json()["name"]
         else:
-            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+            category_name = get(page["category_id"], 'categories/')
+            category_name = category_name.json()["name"]
+            subcategory_name = get(page["subcategory_id"], 'subcategories/')
+            subcategory_name = subcategory_name.json()["name"]
+            category = category_name + "::" + subcategory_name
     return category
 
+    
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()
     venue = get(page["venue_id"], resource='venues').json()

--- a/events/friends_of_kenilworth_gardens.py
+++ b/events/friends_of_kenilworth_gardens.py
@@ -13,6 +13,15 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+def get_category_name(page):
+    if page["category_id"] is None:
+        category = 'none'
+    else:
+        if page["subcategory_id"] is None:
+            category = get(page["category_id"],'categories/').json()["name"]
+        else:
+            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+    return category
 
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()
@@ -35,7 +44,7 @@ def scrape(event_id, event_cost):
         'Event Cost': event_cost,
         'Event Currency Symbol': "$",
         # TODO: parse event data for optional category fields if present
-        'Event Category': "",  
+        'Event Category': get_category_name(page),  
         'Event Website': page['url'],
         'Event Featured Image': ""
     }

--- a/events/friends_of_kenilworth_gardens.py
+++ b/events/friends_of_kenilworth_gardens.py
@@ -16,16 +16,18 @@ except KeyError:
 
 def get_category_name(page):
     if page["category_id"] is None:
-        category = 'none'
+        category = ''
     else:
         if page["subcategory_id"] is None:
             category = get(page["category_id"], 'categories/').json()["name"]
         else:
             category_name = get(page["category_id"], 'categories/')
             category_name = category_name.json()["name"]
+            category_name = category_name.replace(",", "")
             subcategory_name = get(page["subcategory_id"], 'subcategories/')
             subcategory_name = subcategory_name.json()["name"]
-            category = category_name + "::" + subcategory_name
+            subcategory_name = subcategory_name.replace(",", "")
+            category = category_name + "," + subcategory_name
     return category
 
     

--- a/events/nova_parks.py
+++ b/events/nova_parks.py
@@ -13,15 +13,21 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+
 def get_category_name(page):
     if page["category_id"] is None:
         category = 'none'
     else:
         if page["subcategory_id"] is None:
-            category = get(page["category_id"],'categories/').json()["name"]
+            category = get(page["category_id"], 'categories/').json()["name"]
         else:
-            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+            category_name = get(page["category_id"], 'categories/')
+            category_name = category_name.json()["name"]
+            subcategory_name = get(page["subcategory_id"], 'subcategories/')
+            subcategory_name = subcategory_name.json()["name"]
+            category = category_name + "::" + subcategory_name
     return category
+
 
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()

--- a/events/nova_parks.py
+++ b/events/nova_parks.py
@@ -13,6 +13,15 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+def get_category_name(page):
+    if page["category_id"] is None:
+        category = 'none'
+    else:
+        if page["subcategory_id"] is None:
+            category = get(page["category_id"],'categories/').json()["name"]
+        else:
+            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+    return category
 
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()
@@ -35,7 +44,7 @@ def scrape(event_id, event_cost):
         'Event Cost': event_cost,
         'Event Currency Symbol': "$",
         # TODO: parse event data for optional category fields if present
-        'Event Category': "",  
+        'Event Category': get_category_name(page),  
         'Event Website': page['url'],
         'Event Featured Image': ""
     }

--- a/events/nova_parks.py
+++ b/events/nova_parks.py
@@ -16,16 +16,18 @@ except KeyError:
 
 def get_category_name(page):
     if page["category_id"] is None:
-        category = 'none'
+        category = ''
     else:
         if page["subcategory_id"] is None:
             category = get(page["category_id"], 'categories/').json()["name"]
         else:
             category_name = get(page["category_id"], 'categories/')
             category_name = category_name.json()["name"]
+            category_name = category_name.replace(",", "")
             subcategory_name = get(page["subcategory_id"], 'subcategories/')
             subcategory_name = subcategory_name.json()["name"]
-            category = category_name + "::" + subcategory_name
+            subcategory_name = subcategory_name.replace(",", "")
+            category = category_name + "," + subcategory_name
     return category
 
 

--- a/events/riverkeeper.py
+++ b/events/riverkeeper.py
@@ -13,6 +13,15 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+def get_category_name(page):
+    if page["category_id"] is None:
+        category = 'none'
+    else:
+        if page["subcategory_id"] is None:
+            category = get(page["category_id"],'categories/').json()["name"]
+        else:
+            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+    return category
 
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()

--- a/events/riverkeeper.py
+++ b/events/riverkeeper.py
@@ -13,15 +13,21 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+
 def get_category_name(page):
     if page["category_id"] is None:
         category = 'none'
     else:
         if page["subcategory_id"] is None:
-            category = get(page["category_id"],'categories/').json()["name"]
+            category = get(page["category_id"], 'categories/').json()["name"]
         else:
-            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+            category_name = get(page["category_id"], 'categories/')
+            category_name = category_name.json()["name"]
+            subcategory_name = get(page["subcategory_id"], 'subcategories/')
+            subcategory_name = subcategory_name.json()["name"]
+            category = category_name + "::" + subcategory_name
     return category
+    
 
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()

--- a/events/riverkeeper.py
+++ b/events/riverkeeper.py
@@ -16,16 +16,18 @@ except KeyError:
 
 def get_category_name(page):
     if page["category_id"] is None:
-        category = 'none'
+        category = ''
     else:
         if page["subcategory_id"] is None:
             category = get(page["category_id"], 'categories/').json()["name"]
         else:
             category_name = get(page["category_id"], 'categories/')
             category_name = category_name.json()["name"]
+            category_name = category_name.replace(",", "")
             subcategory_name = get(page["subcategory_id"], 'subcategories/')
             subcategory_name = subcategory_name.json()["name"]
-            category = category_name + "::" + subcategory_name
+            subcategory_name = subcategory_name.replace(",", "")
+            category = category_name + "," + subcategory_name
     return category
     
 

--- a/events/sierra_club_md.py
+++ b/events/sierra_club_md.py
@@ -13,16 +13,22 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+
 def get_category_name(page):
     if page["category_id"] is None:
         category = 'none'
     else:
         if page["subcategory_id"] is None:
-            category = get(page["category_id"],'categories/').json()["name"]
+            category = get(page["category_id"], 'categories/').json()["name"]
         else:
-            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+            category_name = get(page["category_id"], 'categories/')
+            category_name = category_name.json()["name"]
+            subcategory_name = get(page["subcategory_id"], 'subcategories/')
+            subcategory_name = subcategory_name.json()["name"]
+            category = category_name + "::" + subcategory_name
     return category
 
+    
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()
     venue = get(page["venue_id"], resource='venues').json()

--- a/events/sierra_club_md.py
+++ b/events/sierra_club_md.py
@@ -13,6 +13,15 @@ try:
 except KeyError:
     EVENTBRITE_TOKEN = input("Enter your Eventbrite Token Key:")
 
+def get_category_name(page):
+    if page["category_id"] is None:
+        category = 'none'
+    else:
+        if page["subcategory_id"] is None:
+            category = get(page["category_id"],'categories/').json()["name"]
+        else:
+            category = get(page["category_id"],'categories/').json()["name"] + "::" + get(page["subcategory_id"],'subcategories/').json()["name"]
+    return category
 
 def scrape(event_id, event_cost):
     page = get(event_id, resource='events').json()
@@ -35,7 +44,7 @@ def scrape(event_id, event_cost):
         'Event Cost': event_cost,
         'Event Currency Symbol': "$",
         # TODO: parse event data for optional category fields if present
-        'Event Category': "",  
+        'Event Category': get_category_name(page),  
         'Event Website': page['url'],
         'Event Featured Image': ""
     }

--- a/events/sierra_club_md.py
+++ b/events/sierra_club_md.py
@@ -16,16 +16,18 @@ except KeyError:
 
 def get_category_name(page):
     if page["category_id"] is None:
-        category = 'none'
+        category = ''
     else:
         if page["subcategory_id"] is None:
             category = get(page["category_id"], 'categories/').json()["name"]
         else:
             category_name = get(page["category_id"], 'categories/')
             category_name = category_name.json()["name"]
+            category_name = category_name.replace(",", "")
             subcategory_name = get(page["subcategory_id"], 'subcategories/')
             subcategory_name = subcategory_name.json()["name"]
-            category = category_name + "::" + subcategory_name
+            subcategory_name = subcategory_name.replace(",", "")
+            category = category_name + "," + subcategory_name
     return category
 
     


### PR DESCRIPTION
Added a function to handle the extraction of the category name. It seems that the good people of eventbrite have a table for categories and a table for subcategories.

If a no category id is present then category is 'none'

If a category is present, say, "Travel & Outdoor" then category is "Travel & Outdoor"

If a subcategory is present AND a category present then both values are concatenated such as "Travel & Outdoor :: Photography"