### PR TITLE
FIX: Events with multiplicity, ignore events w/o registration link

### DIFF
--- a/events/lfwa.py
+++ b/events/lfwa.py
@@ -137,7 +137,8 @@ def parse_event_divs(event_divs):
                 'Event Organizers': 'Little Falls Watershed Alliance',
                 'Event Cost': "0.00",
                 'Event Currency Symbol': "$",
-                # TODO: Get event category from divs with class "eventlist-cats"
+                # TODO: Get event category from divs with class 
+                # "eventlist-cats"
                 'Event Category': "",
                 'Event Website': ORG_URL + event_website,
                 'Event Featured Image': event_img

--- a/events/lfwa.py
+++ b/events/lfwa.py
@@ -148,7 +148,10 @@ def parse_event_divs(event_divs):
             events.append(event_data)
         if not event_registration_websites:
             events.append(event_data)
-            ics_url = ORG_URL + soup_level_two.find("a", {"class" : "eventitem-meta-export-ical"}).get("href")
+            ext = soup_level_two.find(
+                "a", 
+                {"class": "eventitem-meta-export-ical"}).get("href")
+            ics_url = ORG_URL + ext
             c = Calendar(requests.get(ics_url).text)
             e = list(c.timeline)[0]
             date_begin = datetime.fromisoformat(str(e.begin))

--- a/events/lfwa.py
+++ b/events/lfwa.py
@@ -47,7 +47,8 @@ def requests_retry_session(retries=3,
 def get_url(url, org_id=None):
     url = f'{url}{org_id}' if org_id else url    
     try:
-        r = requests_retry_session().get(url)
+        with requests_retry_session() as session:
+            r = session.get(url)
     except Exception as e:
         logger.critical(
             f"Exception making GET request to {url}: {e}", exc_info=True)
@@ -182,7 +183,8 @@ def parse_event_divs(event_divs):
                 "a", 
                 {"class": "eventitem-meta-export-ical"}).get("href")
             ics_url = ORG_URL + ext
-            c = Calendar(requests_retry_session().get(ics_url).text)
+            with requests_retry_session() as session:
+                c = Calendar(session.get(ics_url).text)
             e = list(c.timeline)[0]
             date_begin = datetime.fromisoformat(str(e.begin))
             date_end = datetime.fromisoformat(str(e.end))

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,5 @@ typed-ast==1.2.0
 typing-extensions==3.7.4.1
 urllib3==1.24.2
 wrapt==1.11.1
+pytz==2018.9
+ics==0.7


### PR DESCRIPTION
A for loop that iterates over the <a> tags for the article tag of type "event". In this way we capture events that have a venue multiplicity and avoid events without a registration link.

In addition, the correct status is retrieved with "status_code".

