### PR TITLE
ENH: idempotent lambda and some fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   
   lint:
     docker:
-      - image: circleci/python:3.7.3
+      - image: circleci/python:3.6.8
 
     parallelism: 4
 

--- a/app.py
+++ b/app.py
@@ -29,7 +29,7 @@ class CapitalNatureStack(core.Stack):
             )
         )
 
-        # create lambda to gather domains
+        # create lambda to scrape events
         lambda_scrapers = lambda_.Function(
             self, "scrapers",
             code=lambda_.Code.from_asset('lambda-releases/scrapers.zip'),

--- a/events/lfwa.py
+++ b/events/lfwa.py
@@ -11,6 +11,7 @@ import os
 from urllib3.util.retry import Retry
 
 from bs4 import BeautifulSoup
+from dateutil.parser import isoparse
 from ics import Calendar
 import pytz
 import requests
@@ -187,8 +188,9 @@ def parse_event_divs(event_divs):
             with requests_retry_session() as session:
                 c = Calendar(session.get(ics_url).text)
             e = list(c.timeline)[0]
-            date_begin = datetime.fromisoformat(str(e.begin))
-            date_end = datetime.fromisoformat(str(e.end))
+            # replace fromisoformat, which is not available in python 3.6
+            date_begin = isoparse(str(e.begin))
+            date_end = isoparse(str(e.end))
             est = pytz.timezone('US/Eastern')
             date_begin = date_begin.astimezone(est)
             date_end = date_end.astimezone(est)

--- a/events/utils/aws_utils.py
+++ b/events/utils/aws_utils.py
@@ -100,3 +100,15 @@ def put_object(data, key, bucket=BUCKET):
         S3.put_object(**params)
     except Exception as e:
         logger.error(e, exc_info=True)
+
+
+def object_key_exists(key, bucket=BUCKET):
+    """returns True if an object with the key exists, else False"""
+    response = S3.list_objects_v2(
+        Bucket=bucket,
+        Prefix=key,
+    )
+    for obj in response.get('Contents', []):
+        if obj['Key'] == key:
+            return True
+    return False

--- a/events/utils/aws_utils.py
+++ b/events/utils/aws_utils.py
@@ -103,11 +103,8 @@ def put_object(data, key, bucket=BUCKET):
 
 
 def object_key_exists(key, bucket=BUCKET):
-    """returns True if an object with the key exists, else False"""
-    response = S3.list_objects_v2(
-        Bucket=bucket,
-        Prefix=key,
-    )
+    """returns True if an object with the partial key exists, else False"""
+    response = S3.list_objects_v2(Bucket=bucket, Prefix=key)
     for obj in response.get('Contents', []):
         if key in obj['Key']:
             return True

--- a/events/utils/aws_utils.py
+++ b/events/utils/aws_utils.py
@@ -109,6 +109,6 @@ def object_key_exists(key, bucket=BUCKET):
         Prefix=key,
     )
     for obj in response.get('Contents', []):
-        if obj['Key'] == key:
+        if key in obj['Key']:
             return True
     return False

--- a/events/utils/reports.py
+++ b/events/utils/reports.py
@@ -413,7 +413,7 @@ class ScrapeReport():
                 # Don't put the report if it already exists.
                 # This makes the lambda idempotent for the lambda listening
                 # for this PUT:object S3 event.
-                return
+                pass
             else:
                 put_object(data, self.report_path)
         else:

--- a/lambda-releases/scrapers.zip
+++ b/lambda-releases/scrapers.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:788ea0f6a69c931a5de616408d96035c1aefc67d2b97e6a92adbcba29c347d8c
-size 53889884
+oid sha256:785396079b1953b2a9403e54fdb2473bab52cc56c1078d00cf8ad13235c3a9dc
+size 52672742

--- a/lambda-requirements.txt
+++ b/lambda-requirements.txt
@@ -8,12 +8,12 @@ decorator==4.3.2
 docutils==0.14
 future==0.17.1
 geocoder==1.38.1
+ics==0.7
 idna==2.7
 isort==4.3.10
 jmespath==0.9.3
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
-pylint==2.3.1
 python-dateutil==2.8.0
 ratelim==0.1.6
 requests==2.20.0


### PR DESCRIPTION
Makes the scraper lambda idempotent by only putting the report into s3 if an object with the same file name doesn't already exist in the s3 bucket. Also some minor fixes to `lfwa.py` where python 3.7 functionality was being used. Also changed CircleCI python version to 3.6.8, which is compatible with the AWS lambda runtime, to catch things like this in the future. Addresses #213 in part.